### PR TITLE
Fixed bug with log dir and added instructions for redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 
 ## Usage
 
+Run `redis-server` in a separate terminal.
+
 Edit `config.ini` with your parameters. It's ok to leave `title_kw`, `author_kw`, or `affiliation_kw` blank.
 
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def main():
 	clear_cache = utils.convert_bool(cfg['clear_cache'])
 
 	if not os.path.exists('./.logs'):
-		os.mkdir('./.log')
+		os.mkdir('./.logs')
 	
 	logname = f"./.log/{save_dir.split('/')[-1]}.log"
 	logging.basicConfig(


### PR DESCRIPTION
1. Fixed `logs` instead of `log`
2. Must run redis in a separate terminal to run script